### PR TITLE
Windowed mode cursor workaround

### DIFF
--- a/Mary/Hooks.ixx
+++ b/Mary/Hooks.ixx
@@ -223,12 +223,17 @@ LRESULT User_Hook_WindowProc
 		}
 		case DM_PAUSE:
 		{
+			ImGuiIO& io = ImGui::GetIO();
 			if (g_pause)
 			{
-				Windows_ToggleCursor(true);
+				// FIXME: workaround for unaligned cursor in windowed mode
+				// hide hardware cursor and show software one
+				io.MouseDrawCursor = true;
+				//Windows_ToggleCursor(true);
 			}
 			else
 			{
+				io.MouseDrawCursor = false;
 				if (activeConfig.hideMouseCursor)
 				{
 					Windows_ToggleCursor(false);


### PR DESCRIPTION
Don't show hardware cursor and instead ask ImGui to draw software one with io.MouseDrawCursor, should work for people playing on resolutions lower that 1920x1080 in full screen or in windowed mode.